### PR TITLE
Fix typo in en-US.js

### DIFF
--- a/src/cultures/langs/en-US.js
+++ b/src/cultures/langs/en-US.js
@@ -5,7 +5,7 @@ const ceInputLang = {
   rangeChoise: "Range",
   min: "Min",
   max: "Max",
-  choise: "Choise",
+  choise: "Choose",
   minute: "Minute",
   hours: "Hours",
   dayOfMonth: "Day of Month",


### PR DESCRIPTION
For English, "Choise" would be considered to be misspelled. I have updated it to "Choose", but "Choice" or "Select" might also be appropriate words for this context.

Adding some context here for @JossyDevers to help clarify what might be the proper word based on what you are aiming to achieve:

"Choose" is a verb or "action"  word, i.e. "I choose to...", "You choose a..."
"Choice" is a noun, i.e. "I have a choice to make."
"Select" is also a verb. i.e. " I will select this album to listen to."

Usually when we prompt a user to take an action we use verbs, or action words. That's why I put select as one of the possible options. Select also has a more professional feel to it.

Happy to discuss further if you have questions! 😃 